### PR TITLE
Enable new cops by default

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - !ruby/regexp /vendor\/(?!panoramaed).*$/
     - "db/schema.rb"
     - "db/migrate/**/*"
+  NewCops: enable
 
 Layout/DotPosition:
   EnforcedStyle: trailing


### PR DESCRIPTION
This fixes an issue we're seeing with overcommit, where the error
message does not include the actual errors that occur.