### PR TITLE
Enforce trailing commas in multi-line literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -154,10 +154,10 @@ Style/TrailingCommaInArguments:
   Enabled: false
 
 Style/TrailingCommaInArrayLiteral:
-  Enabled: false
+  EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInHashLiteral:
-  Enabled: false
+  EnforcedStyleForMultiline: comma
 
 RSpec/HookArgument:
   EnforcedStyle: each


### PR DESCRIPTION
This change is being made in accordance with the engineering-wide vote
taken
[here](https://docs.google.com/document/d/13uC7CfYFw8cy9Qoo8zETv3YhZ2OQYhCCb-10a8Y6mkE/edit?ts=5f1b3f6f)