### PR TITLE
Skip RuboCop in node_modules/ directory

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -18,6 +18,7 @@ AllCops:
     - !ruby/regexp /vendor\/(?!panoramaed).*$/
     - "db/schema.rb"
     - "db/migrate/**/*"
+    - "node_modules/**/*"
   NewCops: enable
 
 Gemspec/RequiredRubyVersion:


### PR DESCRIPTION
I noticed that Playbook was getting RuboCop errors like:

```
node_modules/node-sass/src/libsass/contrib/libsass.spec:1:5: E: Lint/Syntax: unexpected token tCOLON
(Using Ruby 2.7 parser; configure using TargetRubyVersion parameter, under AllCops)
Name:           libsass
    ^
node_modules/node-sass/src/libsass/extconf.rb:3:1: C: [Correctable] Layout/LeadingCommentSpace: Missing space after #.
#$LIBPATH.push(Config::CONFIG['libdir'])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
node_modules/node-sass/src/libsass/extconf.rb:4:1: C: Style/GlobalVars: Do not introduce global variables.
$CFLAGS << " #{ENV["CFLAGS"]}"
^^^^^^^
node_modules/node-sass/src/libsass/extconf.rb:4:20: C: [Correctable] Style/StringLiteralsInInterpolation: Prefer single-quoted strings inside interpolations.
$CFLAGS << " #{ENV["CFLAGS"]}"
                   ^^^^^^^^
node_modules/node-sass/src/libsass/extconf.rb:5:1: C: Style/GlobalVars: Do not introduce global variables.
$LIBS << " #{ENV["LIBS"]}"
^^^^^
node_modules/node-sass/src/libsass/extconf.rb:5:18: C: [Correctable] Style/StringLiteralsInInterpolation: Prefer single-quoted strings inside interpolations.
$LIBS << " #{ENV["LIBS"]}"
```

which don't seem like things we should change.

I manually copied this setting into the Playbook `.rubocop.yml` file and confirmed that the RuboCop warnings disappear.