### PR TITLE
SELFS-1359: Rename Rubocop YAML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,5 +19,5 @@ jobs:
           ${{ runner.os }}-gems-
     - run: bundle config path vendor/bundle
     - run: bundle install --jobs 4 --retry 3
-    - run: bundle exec rubocop --config rubocop.yml
+    - run: bundle exec rubocop --config panolint-rubocop.yml
     - run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can use `panolint`'s rubocop configuration in your project with the followin
 
 ```
 inherit_gem:
-  panolint: rubocop.yml
+  panolint: panolint-rubocop.yml
 ```
 
 Note that it for this gem in particular in needs to not be a `.rubocop.yml` file because of rubocop's [path relativity](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#path-relativity).

--- a/lib/panolint/version.rb
+++ b/lib/panolint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panolint
-  VERSION = '0.1.4'
+  VERSION = "0.1.4"
 end

--- a/lib/panolint/version.rb
+++ b/lib/panolint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panolint
-  VERSION = "0.1.3"
+  VERSION = '0.1.4'
 end

--- a/panolint-rubocop.yml
+++ b/panolint-rubocop.yml
@@ -3,7 +3,7 @@
 # You can use this in your project's .rubocop.yml with the following at the top:
 #
 #     inherit_gem:
-#       panolint: rubocop.yml
+#       panolint: panolint-rubocop.yml
 #
 # This allows you to selectively override settings in projects, for example, if
 # you're working on a Sinatra project, disabling the Rails cops is probably

--- a/panolint.gemspec
+++ b/panolint.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "Rules for linting code at Panorama Education"
   spec.homepage      = "https://github.com/panorama-ed/panolint"
   spec.license       = "MIT"
+  spec.metadata      = { "rubygems_mfa_required" => "true" }
 
   spec.files         = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
If you have your code editor set to highlight Rubocop linting errors as you type, some rules aren't getting picked up correctly. Most notably, the block length setting in this repo is getting ignored, so pretty much all of our spec files are getting highlighted in their entirety. Not only is it annoying and distracting, but it also can cover up actual linter errors that should be getting corrected. 

When I searched for a solution to this issue, I found [this GitHub thread in the rubocop repo](https://github.com/rubocop/rubocop/issues/4154#issuecomment-316004878) pointing to how naming a gem's rubocop config as just `rubocop.yaml` messes up the pathing for any project that uses that gem. 

All repos using panolint should do the following:

Update `.rubocop.yml` to change this section...

```yml
inherit_gem:
  panolint: rubocop.yml
```

...to instead say:

```yml
inherit_gem:
  panolint: panolint-rubocop.yml
```

Then, run the following in console on the same PR making the above change: `BUNDLE_GEMFILE=.overcommit/Gemfile bundle update panolint --conservative`

Finally, discard any changes that aren’t to the Panolint version number or revision hash number.

PRs have been opened in all the relevant PRs have been opened and [can be found here](https://panoramaed.atlassian.net/browse/SELFS-1359).