### PR TITLE
ROS-361 Disable Rails/I18nLocaleTexts cop

### DIFF
--- a/lib/panolint/version.rb
+++ b/lib/panolint/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Panolint
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/panolint-rubocop.yml
+++ b/panolint-rubocop.yml
@@ -169,6 +169,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: false
 
+Rails/I18nLocaleTexts:
+  Enabled: false
+
 RSpec/HookArgument:
   EnforcedStyle: each
 
@@ -180,39 +183,3 @@ RSpec/ExampleLength:
 
 RSpec/MultipleExpectations:
   Enabled: false
-
-################################################################################
-# Because of rubocop's new versioning scheme, you get a warning if you don't
-# have config set for specific cops until the next major version comes out. The
-# following rules all mirror the default rubocop configuration, but they're here
-# just to silence the warnings. They can be removed when 1.0 comes out.
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true


### PR DESCRIPTION
The [pending](https://docs.rubocop.org/rubocop/versioning.html#pending-cops) cop [Rails/i18nLocaleTexts](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsi18nlocaletexts) enforces the use of [I18n](https://guides.rubyonrails.org/i18n.html) and locale files. We do not use this structure in Rainbow and while we do seem to use locale files in a small number of cases in Playbook and for devise in NDS, we're currently [considering](https://docs.google.com/document/d/1yrAOu9vyVRkBCrMzyq_9PwWh8Btel-cmBII60eZA1P4/edit#) using Vue I18n in NDS at least. This PR disables the cop in Panolint so we can make case-by-case decisions for how to handle localization in different repositories. The result of doing this will be to proceed as if this cop had not been introduced, not actively changing our current practices. The cop could also be enabled for specific repositories by overriding the setting here in the individual repo, if desired.