### PR TITLE
Cease to maintain versions, fill in previous version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Following panolint version 0.1.6, we stopped formally releasing new panolint ver
 
 This file documents notable changes to the project through version 0.1.6. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Current]
 
 ## [0.1.6] - 2022-10-19
 
@@ -73,7 +73,7 @@ This file documents notable changes to the project through version 0.1.6. The fo
 
 - Initial release. 🎉
 
-[unreleased]: https://github.com/panorama-ed/panolint/compare/v0.1.3...HEAD
+[current]: https://github.com/panorama-ed/panolint/compare/v0.1.6...HEAD
 [0.1.6]: https://github.com/panorama-ed/panolint/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/panorama-ed/panolint/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/panorama-ed/panolint/compare/v0.1.3...v0.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,57 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+Following panolint version 0.1.6, we stopped formally releasing new panolint versions in favor of continually releasing and incorporating the latest iteration of this code.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+This file documents notable changes to the project through version 0.1.6. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.6] - 2022-10-19
+
+### Changed
+
+- Disabled `Rails/I18nLocaleTexts`
+- Removed several redundant configurations
+
+## [0.1.5] - 2022-07-19
+
+### Changed
+
+- Configured `Layout/LineContinuationSpacing` to use `EnforcedStyle: no_space`
+
+## [0.1.4] - 2021-11-29
+
+### Changed
+
+- The `rubocop.yml` file renamed to `panolint-rubocop.yml`.
+- Skip RuboCop in node_modules/ directory
+
 ## [0.1.3] - 2021-04-22
+
+### Added
+
+- Dependabot automation
+
+### Changed
+
+- Enable all new cops by default
+- Explicitly enabled rules:
+  - `Layout/EmptyLinesAroundAttributeAccessor`
+  - `Layout/SpaceAroundMethodCallOperator`
+  - `Style/ExponentialNotation`
+  - `Style/SlicingWithRange`
+  - `Lint/DeprecatedOpenSSLConstant`
+  - `Lint/MixedRegexpCaptureTypes`
+  - `Style/RedundantRegexpCharacterClass`
+  - `Style/RedundantRegexpEscape`
+  - `Lint/DuplicateElsifCondition`
+  - `Style/ArrayCoercion`
+  - `Style/CaseLikeIf`
+  - `Style/HashAsLastArrayItem`
+  - `Style/RedundantFileExtensionInRequire`
+- Explicitly disabled rules:
+  - `Gemspec/RequiredRubyVersion`
+  - `RSpec/MultipleMemoizedHelpers`
 
 ## [0.1.2] - 2020-04-10
 
@@ -29,6 +74,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - Initial release. 🎉
 
 [unreleased]: https://github.com/panorama-ed/panolint/compare/v0.1.3...HEAD
+[0.1.6]: https://github.com/panorama-ed/panolint/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/panorama-ed/panolint/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/panorama-ed/panolint/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/panorama-ed/panolint/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/panorama-ed/panolint/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/panorama-ed/panolint/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A small gem containing rules for linting code at Panorama Education.
 
+Please note that the last numbered version is `0.1.6`. All future changes will simply be added to the main branch of this repository. To use the latest version of this gem, please bundle directly from the github source following the installation instructions in this README.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -10,16 +10,12 @@ A small gem containing rules for linting code at Panorama Education.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'panolint'
+gem "panolint", git: "https://github.com/panorama-ed/panolint.git", branch: "main"
 ```
 
 And then execute:
 
     $ bundle
-
-Or install it yourself as:
-
-    $ gem install panolint
 
 ## Usage
 
@@ -46,7 +42,7 @@ Note that it for this gem in particular in needs to not be a `.rubocop.yml` file
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 

--- a/lib/panolint/version.rb
+++ b/lib/panolint/version.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 module Panolint
-  VERSION = "0.1.7"
+  # We will no longer formally update the version of this code.
+  # Instead, we expect users to install from the latest repository version.
+  # Keep this version frozen at 0.1.6
+  VERSION = "0.1.6"
 end


### PR DESCRIPTION
This PR abandons the use of formal versioning in this repo, making several changes related to versioning:
* Retroactively updates the changelog for previous versions through 0.1.6
* Reverts the version number to the last tagged version (0.1.6) and freezes it there
* Updates installation and development instructions to no longer expect numbered versions